### PR TITLE
plugin/grandtotal: Initialize variables

### DIFF
--- a/plugins/grandtotal
+++ b/plugins/grandtotal
@@ -7,8 +7,8 @@ sub command :Tab(grandtotal) {
 
     return NEXT if $command ne 'grandtotal';
 
-    my $pos;
-    my $neg;
+    my $pos = 0;
+    my $neg = 0;
 
     open my $fh, "<", "revbank.accounts";
     while (defined(my $line = readline $fh)) {


### PR DESCRIPTION
Fixes:
```
Use of uninitialized value $neg in printf at plugins/grandtotal line 21, <$fh> line 2.
Use of uninitialized value $neg in addition (+) at plugins/grandtotal line 22, <$fh> line 2.
```
