### PR TITLE
Permit trailing comments in the product database

### DIFF
--- a/plugins/products
+++ b/plugins/products
@@ -18,6 +18,7 @@ sub read_products() {
     for (slurp $filename) {
         $line++;
 
+        s/#.*$//g;  # remove comment
         s/^\s+|\s+$//g;  # trim
         next if /^#/;
         next if not length;

--- a/plugins/products.pod
+++ b/plugins/products.pod
@@ -20,9 +20,8 @@ The configuration for this plugin lives in a text file called
 C<revbank.products>.
 
 Whitespace at the beginning or end of a line are ignored. Blank lines are
-ignored. Comments are lines that start with C<#> and are also ignored. Note
-that a whole line is either a comment or a data line; trailing comments are
-not supported and C<#> is a valid character in a product description.
+ignored. Comments are lines that start with C<#> and are also ignored.
+Trailing comments are supported.
 
 Data lines have whitespace-separated columns:
 


### PR DESCRIPTION
Please consider permitting trailing comments in product definitions. My use case is to store metadata for automation here.

I checked the product files of Bitlair and Revspace, neither seem to have products with a `#` character in the description.