### PR TITLE
Increase Mollie payment identifier length

### DIFF
--- a/plugins/mollie
+++ b/plugins/mollie
@@ -24,7 +24,7 @@ sub backend_call($hash) {
 
 sub command($self, $cart, $command, @) {
     # currently 10 characters after the underscore, but it's not documented.
-    my ($id) = $command =~ /^(tr_[A-Za-z0-9]{10,12})$/ or return NEXT;
+    my ($id) = $command =~ /^(tr_[A-Za-z0-9]{10,32})$/ or return NEXT;
 
     my $result = eval { backend_call { id => $id } };
     $@ and return REJECT, "API call failed: $@";


### PR DESCRIPTION
Apparently they changed this somewhere in the past 15 hours.

Relevant documentation: https://docs.mollie.com/reference/common-data-types#identifiers

> [...] payment identifiers are prefixed with tr_ [...] Identifiers have a maximum length of 32 characters, including the prefix.

Yes this has been tested in production ;) For more context, see logs at _you know where_ for 9:24 - 9:28 this morning and 18:35 yesterday.